### PR TITLE
hotFix docker-composeからsettings.jsonのアクセス権限を777に変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     depends_on:
       - db
     command: > 
-      bash -c "composer install && apache2-foreground"
+      bash -c "composer install && chmod 777 /var/www/html/setting.json && apache2-foreground"
 
 
   db:


### PR DESCRIPTION
settings.json関連(主にadminUI)でsettings.json保存できなかった不具合を修正